### PR TITLE
Update version and package info in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # exponent-server-sdk-python
 
+## Installation
+
+```
+pip install exponent_server_sdk
+```
+
+## Usage
+
 Use to send push notifications to Exponent Experiences from a Python server.
 
 [Full documentation](https://docs.getexponent.com/versions/v13.0.0/guides/push-notifications.html#http-2-api) on the API is available if you want to dive into the details.

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,25 @@
+from setuptools import find_packages
 from setuptools import setup
+import os
+import re
 
-setup(name='exponent_server_sdk',
-    version='0.0.1',
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+README_PATH = os.path.join(HERE, 'README.md')
+try:
+    with open(README_PATH) as fd:
+        README = fd.read()
+except IOError:
+    README = ''
+
+
+setup(
+    name='exponent_server_sdk',
+    version=__import__('exponent_server_sdk').__version__,
     description='Exponent Server SDK for Python',
+    long_description=README,
     url='https://github.com/exponent/exponent-server-sdk-python',
     author='Exponent Team',
     author_email='exponent.team@gmail.com',
@@ -10,5 +27,6 @@ setup(name='exponent_server_sdk',
     install_requires=[
         'requests',
     ],
-    packages=['exponent_server_sdk'],
-    zip_safe=False)
+    packages=find_packages(),
+    zip_safe=False
+)


### PR DESCRIPTION
@ide if you could update pypi to `0.1.0` after merging, that'd be great so we can depend on that version

Current version: https://pypi.python.org/pypi/exponent_server_sdk/