### PR TITLE
Delay `requests` import to be compatible with CI

### DIFF
--- a/exponent_server_sdk/__init__.py
+++ b/exponent_server_sdk/__init__.py
@@ -2,7 +2,6 @@ __version__ = '0.1.0'
 
 from collections import namedtuple
 import json
-import requests
 
 
 class PushResponseError(Exception):
@@ -224,6 +223,10 @@ class PushClient(object):
         Args:
             push_messages: An array of PushMessage objects.
         """
+        # Delayed import because this file is immediately read on install, and
+        # the requests library may not be installed yet.
+        import requests
+        
         response = requests.post(
             self.host + self.api_url + '/push/send',
             data=json.dumps([pm.get_payload() for pm in push_messages]),

--- a/exponent_server_sdk/__init__.py
+++ b/exponent_server_sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 from collections import namedtuple
 import json
@@ -226,7 +226,7 @@ class PushClient(object):
         # Delayed import because this file is immediately read on install, and
         # the requests library may not be installed yet.
         import requests
-        
+
         response = requests.post(
             self.host + self.api_url + '/push/send',
             data=json.dumps([pm.get_payload() for pm in push_messages]),


### PR DESCRIPTION
Currently, if you freeze requirements and attempt to install from scratch, you get this error:

```
Collecting exponent-server-sdk==0.1.0 (from -r requirements.txt (line 37))
  Downloading exponent_server_sdk-0.1.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-mylsczpa/exponent-server-sdk/setup.py", line 20, in <module>
        version=__import__('exponent_server_sdk').__version__,
      File "/tmp/pip-build-mylsczpa/exponent-server-sdk/exponent_server_sdk/__init__.py", line 5, in <module>
        import requests
    ModuleNotFoundError: No module named 'requests'
```