### PR TITLE
Use isinstance instead of type comparison when checking token type

### DIFF
--- a/exponent_server_sdk/__init__.py
+++ b/exponent_server_sdk/__init__.py
@@ -204,7 +204,7 @@ class PushClient(object):
     def is_exponent_push_token(cls, token):
         """Returns `True` if the token is an Exponent push token"""
 
-        return (type(token) is str) and token.startswith('ExponentPushToken')
+        return isinstance(token, basestring) and token.startswith('ExponentPushToken')
 
     def _publish_internal(self, push_messages):
         """Send push notifications


### PR DESCRIPTION
Allow unicode strings.
When using some web frameworks e.g. Django, string values are stored as unicode characters. Using `type(token) is str` for comparison fails. Using `isinstance(token, basestring)` would be a better option as it accommodates both `str` and `unicode` types.