### PR TITLE
Fix typo in version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='exponent_server_sdk',
-    version='0.0.14',
+    version='0.1.4',
     description='Exponent Server SDK for Python',
     long_description=README,
     url='https://github.com/exponent/exponent-server-sdk-python',


### PR DESCRIPTION
A previous commit changed the version from `0.1.3` to `0.0.14`. The intention was almost certainly to release `0.1.4`, but as a result the "new" version isn't recognised as the latest.