### PR TITLE
Fix Link to PushNotif Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install exponent_server_sdk
 
 Use to send push notifications to Exponent Experiences from a Python server.
 
-[Full documentation](https://docs.expo.io/versions/latest/guides/push-notifications.html#http2-api) on the API is available if you want to dive into the details.
+[Full documentation](https://docs.expo.io/versions/latest/guides/push-notifications#http2-api) on the API is available if you want to dive into the details.
 
 Here's an example on how to use this with retries and reporting via [pyrollbar](https://github.com/rollbar/pyrollbar).
 ```python


### PR DESCRIPTION
Link under "Usage" section to `Full docs` will now point to correct link

Closes [#3920](https://github.com/expo/expo/issues/3920)