### PR TITLE
Add support for push receipt InvalidCredentials error

### DIFF
--- a/exponent_server_sdk/__init__.py
+++ b/exponent_server_sdk/__init__.py
@@ -204,7 +204,9 @@ class PushResponse(
         raise PushResponseError(self)
 
 
-class PushReceiptResponse(object):
+class PushReceiptResponse(
+            namedtuple('PushReceiptResponse',
+                   ['id', 'status', 'message', 'details'])):    
     """Wrapper class for a PushReceipt response. Similar to a PushResponse
 
     A successful single push notification:
@@ -241,13 +243,13 @@ class PushReceiptResponse(object):
         if self.details:
             error = self.details.get('error', None)
 
-            if error == PushResponse.ERROR_DEVICE_NOT_REGISTERED:
+            if error == PushReceiptResponse.ERROR_DEVICE_NOT_REGISTERED:
                 raise DeviceNotRegisteredError(self)
-            elif error == PushResponse.ERROR_MESSAGE_TOO_BIG:
+            elif error == PushReceiptResponse.ERROR_MESSAGE_TOO_BIG:
                 raise MessageTooBigError(self)
-            elif error == PushResponse.ERROR_MESSAGE_RATE_EXCEEDED:
+            elif error == PushReceiptResponse.ERROR_MESSAGE_RATE_EXCEEDED:
                 raise MessageRateExceededError(self)
-            elif error == PushResponse.INVALID_CREDENTIALS:
+            elif error == PushReceiptResponse.INVALID_CREDENTIALS:
                 raise InvalidCredentialsError(self)
 
         # No known error information, so let's raise a generic error.

--- a/exponent_server_sdk/__init__.py
+++ b/exponent_server_sdk/__init__.py
@@ -39,6 +39,19 @@ class MessageRateExceededError(PushResponseError):
     pass
 
 
+class InvalidCredentialsError(PushResponseError):
+    """Raised when our push notification credentials for your standalone app 
+    are invalid (ex: you may have revoked them).
+
+    Run expo build:ios -c to regenerate new push notification credentials for
+    iOS. If you revoke an APN key, all apps that rely on that key will no
+    longer be able to send or receive push notifications until you upload a
+    new key to replace it. Uploading a new APN key will not change your users'
+    Expo Push Tokens.
+    """
+    pass
+
+
 class PushServerError(Exception):
     """Raised when the push token server is not behaving as expected
 
@@ -209,6 +222,7 @@ class PushReceiptResponse(object):
     ERROR_DEVICE_NOT_REGISTERED = 'DeviceNotRegistered'
     ERROR_MESSAGE_TOO_BIG = 'MessageTooBig'
     ERROR_MESSAGE_RATE_EXCEEDED = 'MessageRateExceeded'
+    INVALID_CREDENTIALS = 'InvalidCredentials'
 
     def is_success(self):
         """Returns True if this push notification successfully sent."""
@@ -233,6 +247,8 @@ class PushReceiptResponse(object):
                 raise MessageTooBigError(self)
             elif error == PushResponse.ERROR_MESSAGE_RATE_EXCEEDED:
                 raise MessageRateExceededError(self)
+            elif error == PushResponse.INVALID_CREDENTIALS:
+                raise InvalidCredentialsError(self)
 
         # No known error information, so let's raise a generic error.
         raise PushResponseError(self)


### PR DESCRIPTION
Expo SDK added a `InvalidCredentials` error that can appear in push request receipts. This PR adds support for this error.

Issue: https://github.com/expo-community/expo-server-sdk-python/issues/36