### PR TITLE
change requests to use Sessions, check push receipts in chunks of 1000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 1.1 - 2021-03-14
+- Changed requests library to use Sessions
+- Used chunks for checking push receipts as per expo docs
+
 ## 1.0.3 - 2020-03-08
 - Fixed typo in previous release causing crash sending push tickets
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## [Unreleased]
 
-## 1.1 - 2021-03-14
+## 2.0.0 - 2021-03-17
 - Changed requests library to use Sessions
 - Used chunks for checking push receipts as per expo docs
+- Changing to 2.0.0 to indicate the breaking change in 1.0.2
 
 ## 1.0.3 - 2021-03-08
 - Fixed typo in previous release causing crash sending push tickets
@@ -12,6 +13,7 @@
 ## 1.0.2 - 2021-03-07
 - Renamed variables / classes to confirm with the expo documentation
 - This version will require code modifications (renaming of some classes)
+- Breaking change, should have been renamed to v2.0.0
 
 ## 1.0.1 - 2021-02-15
 - Add support for push receipt InvalidCredentials error

--- a/exponent_server_sdk/__init__.py
+++ b/exponent_server_sdk/__init__.py
@@ -283,6 +283,8 @@ class PushClient(object):
         Args:
             host: The server protocol, hostname, and port.
             api_url: The api url at the host.
+            session: Pass in your own requests.Session object if you prefer 
+                to customize
         """
         self.host = host
         if not self.host:
@@ -298,7 +300,8 @@ class PushClient(object):
             'max_receipt_count'] if 'max_receipt_count' in kwargs else PushClient.DEFAULT_MAX_RECEIPT_COUNT
         self.timeout = kwargs['timeout'] if 'timeout' in kwargs else None
 
-        if not session:
+        self.session = session
+        if not self.session:
             self.session = requests.Session()
             self.session.headers.update({
                 'accept': 'application/json',

--- a/exponent_server_sdk/__init__.py
+++ b/exponent_server_sdk/__init__.py
@@ -443,8 +443,7 @@ class PushClient(object):
         """
         response = session.post(
             self.host + self.api_url + '/push/getReceipts',
-            data=json.dumps(
-                {'ids': [push_ticket.id for push_ticket in push_tickets]}),
+            json={'ids': [push_ticket.id for push_ticket in push_tickets]},
             timeout=self.timeout)
 
         receipts = self.validate_and_get_receipts(response)

--- a/exponent_server_sdk/__init__.py
+++ b/exponent_server_sdk/__init__.py
@@ -298,7 +298,7 @@ class PushClient(object):
             'max_receipt_count'] if 'max_receipt_count' in kwargs else PushClient.DEFAULT_MAX_RECEIPT_COUNT
         self.timeout = kwargs['timeout'] if 'timeout' in kwargs else None
 
-        if not self.session:
+        if not session:
             self.session = requests.Session()
             self.session.headers.update({
                 'accept': 'application/json',

--- a/exponent_server_sdk/__init__.py
+++ b/exponent_server_sdk/__init__.py
@@ -277,7 +277,7 @@ class PushClient(object):
     DEFAULT_MAX_MESSAGE_COUNT = 100
     DEFAULT_MAX_RECEIPT_COUNT = 1000
 
-    def __init__(self, host=None, api_url=None, session, **kwargs):
+    def __init__(self, host=None, api_url=None, session=None, **kwargs):
         """Construct a new PushClient object.
 
         Args:

--- a/exponent_server_sdk/__init__.py
+++ b/exponent_server_sdk/__init__.py
@@ -433,7 +433,7 @@ class PushClient(object):
                                  start + self.max_receipt_count))
             if not chunk:
                 break
-            receipts.extend(self._check_receipts_internal(chunk, self.session))
+            receipts.extend(self._check_receipts_internal(chunk))
         return receipts
 
     def _check_receipts_internal(self, push_tickets):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='exponent_server_sdk',
-    version='1.0.3',
+    version='1.1.0',
     description='Expo Server SDK for Python',
     long_description=README,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='exponent_server_sdk',
-    version='1.1.0',
+    version='2.0.0',
     description='Expo Server SDK for Python',
     long_description=README,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
As per #26 , there was an issue with getting ConnectionErrors when making multiple subsequent requests to the same url.

I'm hoping that changing to sessions could fix this. I'm testing this out currently in my production environment, if I don't see anything then I will assume this fixes the issues.

- Added a couple parameters to the PushMessage as per https://docs.expo.io/push-notifications/sending-notifications/
- Made push receipt checking every 1000 as per expo docs
