### PR TITLE
Correct year in changelog for recent releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## [Unreleased]
 
-## 1.0.3 - 2020-03-08
+## 1.0.3 - 2021-03-08
 - Fixed typo in previous release causing crash sending push tickets
 
-## 1.0.2 - 2020-03-07
+## 1.0.2 - 2021-03-07
 - Renamed variables / classes to confirm with the expo documentation
 - This version will require code modifications (renaming of some classes)
 
-## 1.0.1 - 2020-02-15
+## 1.0.1 - 2021-02-15
 - Add support for push receipt InvalidCredentials error
 
 ## 1.0.0 - 2020-11-17


### PR DESCRIPTION
Either this PR is correct, or your PyPI account has been hacked :S 

PyPI releases:

![Screenshot from 2021-03-15 10-52-01](https://user-images.githubusercontent.com/471170/111142364-82184680-857c-11eb-9b3f-60cfc93dbcb5.png)
