### PR TITLE
Return PushReceipts instead of PushTickets from validate_and_get_receipts()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# PyCharm
+.idea

--- a/exponent_server_sdk/__init__.py
+++ b/exponent_server_sdk/__init__.py
@@ -501,9 +501,11 @@ class PushClient(object):
         ret = []
         for r_id, val in response_data.items():
             ret.append(
-                PushTicket(push_message=PushMessage(),
-                           status=val.get('status', PushTicket.ERROR_STATUS),
-                           message=val.get('message', ''),
-                           details=val.get('details', None),
-                           id=r_id))
+                PushReceipt(
+                    status=val.get('status', PushReceipt.ERROR_STATUS),
+                    message=val.get('message', ''),
+                    details=val.get('details', None),
+                    id=r_id
+                )
+            )
         return ret


### PR DESCRIPTION
I guess the idea was to return the PushReceipt() objects, as we're getting data from /push/getReceipts