### PR TITLE
Add use fcm v1 parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## 2.1.0 - 2024-03-14
+- Added optional parameter force_fcm_v1 for PushClient initialization. If True, it will send Android notifications via FCM V1.
+
 ## 2.0.0 - 2021-03-17
 - Changed requests library to use Sessions
 - Used chunks for checking push receipts as per expo docs

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install exponent_server_sdk
 
 Use to send push notifications to Exponent Experiences from a Python server.
 
-[Full documentation](https://docs.expo.io/versions/latest/guides/push-notifications#http2-api) on the API is available if you want to dive into the details.
+[Full documentation](https://docs.expo.dev/push-notifications/sending-notifications/#http2-api) on the API is available if you want to dive into the details.
 
 Here's an example on how to use this with retries and reporting via [pyrollbar](https://github.com/rollbar/pyrollbar).
 ```python

--- a/exponent_server_sdk/__init__.py
+++ b/exponent_server_sdk/__init__.py
@@ -276,15 +276,18 @@ class PushClient(object):
     DEFAULT_BASE_API_URL = "/--/api/v2"
     DEFAULT_MAX_MESSAGE_COUNT = 100
     DEFAULT_MAX_RECEIPT_COUNT = 1000
+    DEFAULT_FORCE_FCM_V1 = False
 
-    def __init__(self, host=None, api_url=None, session=None, **kwargs):
+    def __init__(self, host=None, api_url=None, session=None, force_fcm_v1=None, **kwargs):
         """Construct a new PushClient object.
 
         Args:
             host: The server protocol, hostname, and port.
             api_url: The api url at the host.
-            session: Pass in your own requests.Session object if you prefer 
+            session: Pass in your own requests.Session object if you prefer
                 to customize
+            force_fcm_v1: If True, send Android notifications via FCM V1, regardless
+                of whether a valid credential exists.
         """
         self.host = host
         if not self.host:
@@ -293,6 +296,10 @@ class PushClient(object):
         self.api_url = api_url
         if not self.api_url:
             self.api_url = PushClient.DEFAULT_BASE_API_URL
+
+        self.force_fcm_v1 = force_fcm_v1
+        if not self.force_fcm_v1:
+            self.force_fcm_v1 = PushClient.DEFAULT_FORCE_FCM_V1
 
         self.max_message_count = kwargs[
             'max_message_count'] if 'max_message_count' in kwargs else PushClient.DEFAULT_MAX_MESSAGE_COUNT
@@ -335,8 +342,12 @@ class PushClient(object):
             push_messages: An array of PushMessage objects.
         """
 
+        url = self.host + self.api_url + '/push/send'
+        if self.force_fcm_v1:
+            url += '?useFcmV1=true'
+
         response = self.session.post(
-            self.host + self.api_url + '/push/send',
+            url,
             data=json.dumps([pm.get_payload() for pm in push_messages]),
             timeout=self.timeout)
 

--- a/exponent_server_sdk/__init__.py
+++ b/exponent_server_sdk/__init__.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 import json
 import itertools
 import requests
+from urllib.parse import urljoin, urlencode
 
 
 class PushTicketError(Exception):
@@ -276,7 +277,6 @@ class PushClient(object):
     DEFAULT_BASE_API_URL = "/--/api/v2"
     DEFAULT_MAX_MESSAGE_COUNT = 100
     DEFAULT_MAX_RECEIPT_COUNT = 1000
-    DEFAULT_FORCE_FCM_V1 = False
 
     def __init__(self, host=None, api_url=None, session=None, force_fcm_v1=None, **kwargs):
         """Construct a new PushClient object.
@@ -298,8 +298,6 @@ class PushClient(object):
             self.api_url = PushClient.DEFAULT_BASE_API_URL
 
         self.force_fcm_v1 = force_fcm_v1
-        if not self.force_fcm_v1:
-            self.force_fcm_v1 = PushClient.DEFAULT_FORCE_FCM_V1
 
         self.max_message_count = kwargs[
             'max_message_count'] if 'max_message_count' in kwargs else PushClient.DEFAULT_MAX_MESSAGE_COUNT
@@ -342,9 +340,10 @@ class PushClient(object):
             push_messages: An array of PushMessage objects.
         """
 
-        url = self.host + self.api_url + '/push/send'
-        if self.force_fcm_v1:
-            url += '?useFcmV1=true'
+        url = urljoin(self.host, self.api_url + '/push/send')
+        if self.force_fcm_v1 is not None:
+            query_params = {'useFcmV1': 'true' if self.force_fcm_v1 else 'false'}
+            url += '?' + urlencode(query_params)
 
         response = self.session.post(
             url,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='exponent_server_sdk',
-    version='2.0.0',
+    version='2.1.0',
     description='Expo Server SDK for Python',
     long_description=README,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Why?
[Expo added support for FCM HTTP v1 API](https://expo.dev/blog/expo-adds-support-for-fcm-http-v1-api)

How?
I added an optional parameter `force_fcm_v1` to the PublishClient initialization.

Test?
I tested it locally with and without the above parameter.

Will close issue #62

